### PR TITLE
Endpoints for expenses grouping + tech debt clean up

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: yarn start:prod

--- a/README.md
+++ b/README.md
@@ -117,14 +117,14 @@ $ npx prisma studio
 
 ### Query income by payment method and calculate sum of income by payment method
 ```graphql
-# Note: dateEndInc and dateStartInc are optional.
+# Note: endDate and dateStartInc are optional.
 # When date filters are not provided, the query will return all records`
 query {
   incomeGroupBy ( 
   	field: "paymentMethod",
     valueType: "sum"
-    dateEndInc: "Sun Nov 21 2021 12:12:28 GMT+1300 (New Zealand Daylight Time)"
-    dateStartInc: "Wed Sep 01 2021 12:12:28 GMT+1200 (New Zealand Standard Time)"
+    endDate: "Sun Nov 21 2021 12:12:28 GMT+1300 (New Zealand Daylight Time)"
+    startDate: "Wed Sep 01 2021 12:12:28 GMT+1200 (New Zealand Standard Time)"
   ) {
     incomePaymentMethod
     sum
@@ -226,8 +226,8 @@ query {
   incomeGroupBy ( 
   	field: "date",
     valueType: "sum"
-    dateStartInc: "Sun Nov 21 2021 12:12:28 GMT+1300 (New Zealand Daylight Time)"
-    dateEndInc: "Tue Nov 23 2021 13:00:00 GMT+1300 (New Zealand Daylight Time)"
+    startDate: "Sun Nov 21 2021 12:12:28 GMT+1300 (New Zealand Daylight Time)"
+    endDate: "Tue Nov 23 2021 13:00:00 GMT+1300 (New Zealand Daylight Time)"
   ) {
     date
     sum
@@ -260,8 +260,8 @@ query {
 query {
   averageIncome (
     type: "daily"
-    dateStartInc: "Thu Jul 01 2021 12:00:00 GMT+1200 (New Zealand Standard Time)"
-    dateEndInc: "Tue Sep 28 2021 13:00:00 GMT+1300 (New Zealand Daylight Time)"
+    startDate: "Thu Jul 01 2021 12:00:00 GMT+1200 (New Zealand Standard Time)"
+    endDate: "Tue Sep 28 2021 13:00:00 GMT+1300 (New Zealand Daylight Time)"
   ) {
     type
     average

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,7 +7,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DB_LOCAL_URL")
+  url      = env("DB_SUPABASE_URL")
 }
 
 model Income {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -167,3 +167,11 @@ if (toSeedNewIncome) {
       await prisma.$disconnect();
     });
 }
+
+export const clearAllIncome = async () => {
+  await prisma.income.deleteMany();
+};
+
+export const clearAllExpenses = async () => {
+  await prisma.expense.deleteMany();
+};

--- a/src/notion/notion.dto.ts
+++ b/src/notion/notion.dto.ts
@@ -57,14 +57,14 @@ export type AverageIncomeExpensesType = 'daily' | 'weekly' | 'monthly';
 export interface IncomeGroupQueryParam {
   field: IncomeQueryParams;
   valueType: ValueType;
-  dateStartInc?: Date;
-  dateEndInc?: Date;
+  startDate?: Date;
+  endDate?: Date;
 }
 
 export interface AverageIncomeExpenseQueryParams {
   type: AverageIncomeExpensesType;
-  dateStartInc: Date;
-  dateEndInc: Date;
+  startDate: Date;
+  endDate: Date;
 }
 
 export interface IncomeAndExpensesSumParams {

--- a/src/notion/notion.dto.ts
+++ b/src/notion/notion.dto.ts
@@ -61,6 +61,13 @@ export interface IncomeGroupQueryParam {
   endDate?: Date;
 }
 
+export interface ExpensesGroupQueryParam {
+  field: ExpenseQueryParams;
+  valueType: ValueType;
+  startDate?: Date;
+  endDate?: Date;
+}
+
 export interface AverageIncomeExpenseQueryParams {
   type: AverageIncomeExpensesType;
   startDate: Date;

--- a/src/notion/notion.entity.ts
+++ b/src/notion/notion.entity.ts
@@ -137,6 +137,12 @@ export class AverageIncome extends BaseAverage {
   average: number;
 }
 
+@ObjectType()
+export class AverageExpenses extends BaseAverage {
+  @Field()
+  average: number;
+}
+
 export class BaseSum {
   @Field({ nullable: true })
   startDate?: Date;

--- a/src/notion/notion.entity.ts
+++ b/src/notion/notion.entity.ts
@@ -81,10 +81,10 @@ export class BaseGroupByQueryReturnedFields {
 
   // date_filters_inputted_by_user
   @Field({ nullable: true })
-  dateStartInc?: Date;
+  startDate?: Date;
 
   @Field({ nullable: true })
-  dateEndInc?: Date;
+  endDate?: Date;
 
   // aggregated_value_types
   @Field({ nullable: true })
@@ -122,10 +122,10 @@ export class ExpenseGroupByQuery extends BaseGroupByQueryReturnedFields {
 
 export class BaseAverage {
   @Field({ nullable: true })
-  dateStartInc?: Date;
+  startDate?: Date;
 
   @Field({ nullable: true })
-  dateEndInc?: Date;
+  endDate?: Date;
 }
 
 @ObjectType()

--- a/src/notion/notion.resolver.ts
+++ b/src/notion/notion.resolver.ts
@@ -221,6 +221,29 @@ export class NotionResolver {
     return [];
   }
 
+  @Query(() => [AverageIncome])
+  @UseGuards(GqlAuth0Guard)
+  protected async averageExpenses(
+    @Args('startDate', { type: () => Date })
+    startDate: Date,
+
+    @Args('endDate', { type: () => Date })
+    endDate: Date,
+  ) {
+    const expenses = await this.notionService.expenseSumByDateRange({
+      startDate,
+      endDate,
+    });
+    const days = getNumberOfDaysBetween(startDate, endDate);
+    const amount = expenses._sum.amount;
+    const average = (amount / days).toFixed(2);
+    return [
+      {
+        average,
+      },
+    ];
+  }
+
   @Query(() => [TotalIncomeAndExpenses])
   @UseGuards(GqlAuth0Guard)
   protected async incomeSum(

--- a/src/notion/notion.service.ts
+++ b/src/notion/notion.service.ts
@@ -89,8 +89,8 @@ export class NotionService {
             by: ['paymentMethod'],
             where: {
               date: {
-                gte: params?.dateStartInc,
-                lte: params?.dateEndInc,
+                gte: params?.startDate,
+                lte: params?.endDate,
               },
               incomeType: {
                 not: 'Investment Cashout',
@@ -105,8 +105,8 @@ export class NotionService {
             by: ['paymentMethod'],
             where: {
               date: {
-                gte: params?.dateStartInc,
-                lte: params?.dateEndInc,
+                gte: params?.startDate,
+                lte: params?.endDate,
               },
               incomeType: {
                 not: 'Investment Cashout',
@@ -123,8 +123,8 @@ export class NotionService {
             by: ['paidBy'],
             where: {
               date: {
-                gte: params?.dateStartInc,
-                lte: params?.dateEndInc,
+                gte: params?.startDate,
+                lte: params?.endDate,
               },
               incomeType: {
                 not: 'Investment Cashout',
@@ -139,8 +139,8 @@ export class NotionService {
             by: ['paidBy'],
             where: {
               date: {
-                gte: params?.dateStartInc,
-                lte: params?.dateEndInc,
+                gte: params?.startDate,
+                lte: params?.endDate,
               },
               incomeType: {
                 not: 'Investment Cashout',
@@ -157,8 +157,8 @@ export class NotionService {
             by: ['incomeType'],
             where: {
               date: {
-                gte: params?.dateStartInc,
-                lte: params?.dateEndInc,
+                gte: params?.startDate,
+                lte: params?.endDate,
               },
               incomeType: {
                 not: 'Investment Cashout',
@@ -173,8 +173,8 @@ export class NotionService {
             by: ['incomeType'],
             where: {
               date: {
-                gte: params?.dateStartInc,
-                lte: params?.dateEndInc,
+                gte: params?.startDate,
+                lte: params?.endDate,
               },
               incomeType: {
                 not: 'Investment Cashout',
@@ -191,8 +191,8 @@ export class NotionService {
             by: ['currency'],
             where: {
               date: {
-                gte: params?.dateStartInc,
-                lte: params?.dateEndInc,
+                gte: params?.startDate,
+                lte: params?.endDate,
               },
               incomeType: {
                 not: 'Investment Cashout',
@@ -209,8 +209,8 @@ export class NotionService {
             by: ['date'],
             where: {
               date: {
-                gte: params?.dateStartInc,
-                lte: params?.dateEndInc,
+                gte: params?.startDate,
+                lte: params?.endDate,
               },
               incomeType: {
                 not: 'Investment Cashout',
@@ -231,8 +231,8 @@ export class NotionService {
     return await this.prisma.income.findMany({
       where: {
         date: {
-          gte: params.dateStartInc,
-          lte: params.dateEndInc,
+          gte: params.startDate,
+          lte: params.endDate,
         },
         incomeType: {
           not: 'Investment Cashout',

--- a/src/notion/notion.service.ts
+++ b/src/notion/notion.service.ts
@@ -3,6 +3,7 @@ import { ExpenseRow, IncomeRow } from './notion.entity';
 import {
   AverageIncomeExpenseQueryParams,
   ExpenseQueryParams,
+  ExpensesGroupQueryParam,
   IncomeAndExpensesSumParams,
   IncomeGroupQueryParam,
   IncomeQueryParams,
@@ -80,7 +81,6 @@ export class NotionService {
   }
 
   public async incomeQueryByGroup(params: IncomeGroupQueryParam) {
-    // console.table(params);
     const { field, valueType } = params;
     switch (field) {
       case 'paymentMethod':
@@ -214,6 +214,114 @@ export class NotionService {
               },
               incomeType: {
                 not: 'Investment Cashout',
+              },
+            },
+            _sum: {
+              amount: true,
+            },
+            orderBy: {
+              date: 'asc',
+            },
+          });
+        }
+    }
+  }
+
+  public async expensesQueryByGroup(params: ExpensesGroupQueryParam) {
+    const { field, valueType } = params;
+    switch (field) {
+      case 'type':
+        if (valueType === 'sum') {
+          return await this.prisma.expense.groupBy({
+            by: ['type'],
+            where: {
+              date: {
+                gte: params?.startDate,
+                lte: params?.endDate,
+              },
+            },
+            _sum: {
+              amount: true,
+            },
+          });
+        } else if (valueType === 'count') {
+          return await this.prisma.expense.groupBy({
+            by: ['type'],
+            where: {
+              date: {
+                gte: params?.startDate,
+                lte: params?.endDate,
+              },
+            },
+            _count: {
+              type: true,
+            },
+          });
+        }
+      case 'subType':
+        if (valueType === 'sum') {
+          return await this.prisma.expense.groupBy({
+            by: ['subType'],
+            where: {
+              date: {
+                gte: params?.startDate,
+                lte: params?.endDate,
+              },
+            },
+            _sum: {
+              amount: true,
+            },
+          });
+        } else if (valueType === 'count') {
+          return await this.prisma.expense.groupBy({
+            by: ['subType'],
+            where: {
+              date: {
+                gte: params?.startDate,
+                lte: params?.endDate,
+              },
+            },
+            _count: {
+              subType: true,
+            },
+          });
+        }
+      case 'paymentType':
+        if (valueType === 'sum') {
+          return await this.prisma.expense.groupBy({
+            by: ['paymentType'],
+            where: {
+              date: {
+                gte: params?.startDate,
+                lte: params?.endDate,
+              },
+            },
+            _sum: {
+              amount: true,
+            },
+          });
+        } else if (valueType === 'count') {
+          return await this.prisma.expense.groupBy({
+            by: ['paymentType'],
+            where: {
+              date: {
+                gte: params?.startDate,
+                lte: params?.endDate,
+              },
+            },
+            _count: {
+              paymentType: true,
+            },
+          });
+        }
+      case 'date':
+        if (valueType === 'sum') {
+          return await this.prisma.expense.groupBy({
+            by: ['date'],
+            where: {
+              date: {
+                gte: params?.startDate,
+                lte: params?.endDate,
               },
             },
             _sum: {

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -45,8 +45,8 @@ type IncomeGroupByQuery {
   dateLastUpdated: String
   dateDeleted: String
   deleted: String
-  dateStartInc: DateTime
-  dateEndInc: DateTime
+  startDate: DateTime
+  endDate: DateTime
   sum: Float
   count: Float
   incomePaidBy: String
@@ -66,8 +66,9 @@ type TotalIncomeAndExpenses {
 type Query {
   income(count: Int, sortDateBy: String, currency: String, date: DateTime, incomeType: String, paidBy: String, paymentMethod: String): [IncomeRow!]!
   expense(count: Int, sortDateBy: String, paymentType: String, subType: String, type: String, item: String, currency: String, amount: Int, date: DateTime, id: Int): [ExpenseRow!]!
-  incomeGroupBy(dateEndInc: DateTime, dateStartInc: DateTime, valueType: String!, field: String!): [IncomeGroupByQuery!]!
-  averageIncome(dateEndInc: DateTime!, dateStartInc: DateTime!, type: String!): [AverageIncome!]!
+  incomeGroupBy(endDate: DateTime, startDate: DateTime, valueType: String!, field: String!): [IncomeGroupByQuery!]!
+  averageIncome(endDate: DateTime!, startDate: DateTime!, type: String!): [AverageIncome!]!
   incomeSum(endDate: DateTime, startDate: DateTime): [TotalIncomeAndExpenses!]!
   expenseSum(endDate: DateTime, startDate: DateTime): [TotalIncomeAndExpenses!]!
+  netIncome(endDate: DateTime, startDate: DateTime): [TotalIncomeAndExpenses!]!
 }

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -54,6 +54,22 @@ type IncomeGroupByQuery {
   incomeType: String
 }
 
+type ExpenseGroupByQuery {
+  currency: String
+  date: String
+  dateCreated: String
+  dateLastUpdated: String
+  dateDeleted: String
+  deleted: String
+  startDate: DateTime
+  endDate: DateTime
+  sum: Float
+  count: Float
+  expenseType: String
+  expenseSubType: String
+  expensePaymentType: String
+}
+
 type AverageIncome {
   type: String!
   average: Float!
@@ -67,6 +83,7 @@ type Query {
   income(count: Int, sortDateBy: String, currency: String, date: DateTime, incomeType: String, paidBy: String, paymentMethod: String): [IncomeRow!]!
   expense(count: Int, sortDateBy: String, paymentType: String, subType: String, type: String, item: String, currency: String, amount: Int, date: DateTime, id: Int): [ExpenseRow!]!
   incomeGroupBy(endDate: DateTime, startDate: DateTime, valueType: String!, field: String!): [IncomeGroupByQuery!]!
+  expensesGroupBy(endDate: DateTime, startDate: DateTime, valueType: String!, field: String!): [ExpenseGroupByQuery!]!
   averageIncome(endDate: DateTime!, startDate: DateTime!, type: String!): [AverageIncome!]!
   averageExpenses(endDate: DateTime!, startDate: DateTime!): [AverageIncome!]!
   incomeSum(endDate: DateTime, startDate: DateTime): [TotalIncomeAndExpenses!]!

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -68,6 +68,7 @@ type Query {
   expense(count: Int, sortDateBy: String, paymentType: String, subType: String, type: String, item: String, currency: String, amount: Int, date: DateTime, id: Int): [ExpenseRow!]!
   incomeGroupBy(endDate: DateTime, startDate: DateTime, valueType: String!, field: String!): [IncomeGroupByQuery!]!
   averageIncome(endDate: DateTime!, startDate: DateTime!, type: String!): [AverageIncome!]!
+  averageExpenses(endDate: DateTime!, startDate: DateTime!): [AverageIncome!]!
   incomeSum(endDate: DateTime, startDate: DateTime): [TotalIncomeAndExpenses!]!
   expenseSum(endDate: DateTime, startDate: DateTime): [TotalIncomeAndExpenses!]!
   netIncome(endDate: DateTime, startDate: DateTime): [TotalIncomeAndExpenses!]!


### PR DESCRIPTION
Changes:
1. Added endpoint for querying expenses by grouping
2. Added endpoint for querying expenses average
3. Added endpoint for querying net income
4. Tech debt clean up: Changed all `dateStartInc` and `dateEndInc` to `startDate` and `endDate`
5. Added procfile for heroku deployment